### PR TITLE
Correction with Laravel Octane

### DIFF
--- a/resources/views/livewire/requests-graph.blade.php
+++ b/resources/views/livewire/requests-graph.blade.php
@@ -50,16 +50,19 @@
             <div wire:key="requests-graph">
 
                 @php
-                function hightestValue($data){
-                    $highest = 0;
-
-                    foreach($data as $item) {
-                        $max = max($item);
-                        $highest = $max > $highest ? $max : $highest;
+                if(!function_exists('hightestValue')){
+                    function hightestValue($data){
+                        $highest = 0;
+    
+                        foreach($data as $item) {
+                            $max = max($item);
+                            $highest = $max > $highest ? $max : $highest;
+                        }
+    
+                        return $highest;
                     }
-
-                    return $highest;
                 }
+                
 
                 $highest = hightestValue($request->toArray());
                 @endphp


### PR DESCRIPTION
Fix bug when using Laravel Octane: Cannot redeclare hightestValue().