### PR TITLE
Fix for tooltips not showing values

### DIFF
--- a/resources/views/livewire/requests-graph.blade.php
+++ b/resources/views/livewire/requests-graph.blade.php
@@ -204,7 +204,7 @@
                             intersect: false,
                             callbacks: {
                                 beforeBody: (context) => context
-                                    .filter(item => item.formattedValue > 0)
+                                    .filter(item => item.raw > 0)
                                     .map(item => `${item.dataset.label}: ${data.sampleRate < 1 ? '~' : ''}${item.formattedValue}`)
                                     .join(', '),
                                 label: () => null,


### PR DESCRIPTION
When displaying tooltips, they only contain values ​​greater than zero. This is done by filtering:

`.filter(item => item.formattedValue > 0)`

However, `formattedValue` is a string, and additionally - if I understand correctly - formatted according to the user's local settings. This causes situations where values ​​greater than zero are incorrectly filtered out. Therefore, we should refer to the `raw` parameter:

`.filter(item => item.raw > 0)`

Closes #8