### PR TITLE
Fix for no color for Informational requests

### DIFF
--- a/resources/views/livewire/requests-graph.blade.php
+++ b/resources/views/livewire/requests-graph.blade.php
@@ -9,7 +9,7 @@
             <div class="flex flex-wrap gap-4">
                 @if ($config['record_informational'])
                 <div class="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400 font-medium">
-                    <div class="h-0.5 w-3 rounded-full bg-[rgba(29,153,172,0.5)]"></div>
+                    <div class="h-0.5 w-3 rounded-full" style="background-color: rgba(29,153,172,0.5)"></div>
                     Informational
                 </div>
                 @endif


### PR DESCRIPTION
I define a color for Informational requests in the chart header. To keep it simple I use inline CSS.

Closes #12